### PR TITLE
Allow arguments in `compiler` and `elmTestCompiler` config settings

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -157,7 +157,11 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
     if (utils.isWindows) {
       make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
     } else {
-      make = cp.spawn(makeCommand, args, { cwd: cwd });
+      const makeCommandParts = makeCommand.split(" ");
+      make = cp.spawn(
+        makeCommandParts[0],
+        [...args, ...makeCommandParts.slice(1)], { cwd: cwd }
+      );
     }
     // output is actually optional
     // (fixed in https://github.com/Microsoft/vscode/commit/b4917afe9bdee0e9e67f4094e764f6a72a997c70,

--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -156,7 +156,7 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
 
     make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
 
-      // output is actually optional
+    // output is actually optional
     // (fixed in https://github.com/Microsoft/vscode/commit/b4917afe9bdee0e9e67f4094e764f6a72a997c70,
     // but unreleased at this time)
     const errorLinesFromElmMake = readline.createInterface({

--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -154,16 +154,9 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
         : compiler
       : make018Command;
 
-    if (utils.isWindows) {
-      make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
-    } else {
-      const makeCommandParts = makeCommand.split(" ");
-      make = cp.spawn(
-        makeCommandParts[0],
-        [...args, ...makeCommandParts.slice(1)], { cwd: cwd }
-      );
-    }
-    // output is actually optional
+    make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
+
+      // output is actually optional
     // (fixed in https://github.com/Microsoft/vscode/commit/b4917afe9bdee0e9e67f4094e764f6a72a997c70,
     // but unreleased at this time)
     const errorLinesFromElmMake = readline.createInterface({

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -40,8 +40,9 @@ function getMakeAndArguments(file, warn: boolean): [string, string, string[]] {
       ? elmTestCompiler
       : compiler
     : make018Command;
+  const makeCommandParts = makeCommand.split(" ");
 
-  return [cwd, makeCommand, args];
+  return [cwd, makeCommandParts[0], [...args, ...makeCommandParts.slice(1)]];
 }
 
 function execMake(editor: vscode.TextEditor, warn: boolean): void {

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -40,9 +40,7 @@ function getMakeAndArguments(file, warn: boolean): [string, string, string[]] {
       ? elmTestCompiler
       : compiler
     : make018Command;
-  const makeCommandParts = makeCommand.split(" ");
-
-  return [cwd, makeCommandParts[0], [...args, ...makeCommandParts.slice(1)]];
+  return [cwd, makeCommand, args];
 }
 
 function execMake(editor: vscode.TextEditor, warn: boolean): void {
@@ -57,12 +55,7 @@ function execMake(editor: vscode.TextEditor, warn: boolean): void {
     let file = editor.document.fileName;
     let [cwd, makeCommand, args] = getMakeAndArguments(file, warn);
 
-    if (utils.isWindows) {
-      make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
-    } else {
-      make = cp.spawn(makeCommand, args, { cwd: cwd });
-    }
-
+    make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
     make.stdout.on('data', (data: Buffer) => {
       if (data) {
         oc.append(data.toString());


### PR DESCRIPTION
***I'm happy to listen to ideas or criticism. What I've done on this PR may not be the best way to achieve what I want!***

Currently on non-Windows platforms the config settings `compiler` and `elmTestCompiler` are used as the first argument to `cp.spawn()` which means you can't include any arguments, e.g.

```
"elm.elmTestCompiler": "./node_modules/.bin/elm-test --compiler=./node_modules/.bin/elm",
```

or

```
"elm.elmTestCompiler": "npx elm-test",
```

This PR basically just removes the platform detection and calls `cp.exec` everywhere, so that arguments are parsed correctly.

My first attempt was to split the `compiler` value on spaces and pass the tail as arguments, but I can see that having CONSEQUENCES.

A third route might be to add a `compilerOptions` configuration? But that seems more complicated and less discoverable.

Happy to take feedback on this.

PS I'm seeing some test failures relating to launching processes but I'm also seeing them on `master`. I'm not sure if I've made them worse. If the tests are working for other people on `master` I'll need to work on getting them running.