### PR TITLE
Go to module definition from imports

### DIFF
--- a/src/elmWorkspaceSymbols.ts
+++ b/src/elmWorkspaceSymbols.ts
@@ -31,7 +31,7 @@ export class ElmWorkspaceSymbolProvider
   ): Promise<vscode.SymbolInformation[]> {
     const [sourceModule, symbolName] = query.split(':', 2);
 
-    if (symbolName == null) {
+    if (symbolName === undefined || symbolName === "") {
       return this.searchWorkspaceSymbols(sourceModule);
     }
 


### PR DESCRIPTION
This change enables to go to module definition from `import XXX.XXX`.

![image](https://user-images.githubusercontent.com/2568148/55938338-21887c80-5c76-11e9-865f-c6ee04cf3823.png)
