### PR TITLE
Updated syntax file

### DIFF
--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -472,7 +472,7 @@
           "name": "storage.type.elm"
         }
       },
-      "end": "^\\n$",
+      "end": "^(?![\\s\\n]*\\s*\\S)",
       "name": "meta.function.type-declaration.elm",
       "patterns": [
         {
@@ -531,7 +531,7 @@
           "name": "storage.type.elm"
         }
       },
-      "end": "^\\n$",
+      "end": "^(?![\\s\\n]*\\s*\\S)",
       "name": "meta.function.type-declaration.elm",
       "patterns": [
         {

--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -472,7 +472,7 @@
           "name": "storage.type.elm"
         }
       },
-      "end": "^(?![\\s\\n]*\\s*\\S)",
+      "end": "^(?=\\S)",
       "name": "meta.function.type-declaration.elm",
       "patterns": [
         {
@@ -531,7 +531,7 @@
           "name": "storage.type.elm"
         }
       },
-      "end": "^(?![\\s\\n]*\\s*\\S)",
+      "end": "^(?=\\S)",
       "name": "meta.function.type-declaration.elm",
       "patterns": [
         {


### PR DESCRIPTION
Solved an annoying bug in syntax highlighting where type declaration doesn't end in the right place. Solved by updating the end regex of type-declaration and type-alias-declaration.

**Before**

![Screenshot_20191205_230318](https://user-images.githubusercontent.com/5395277/70295370-c97a2980-17b4-11ea-8b3c-aa63d65f44d4.png)

**After**

![Screenshot_20191205_225811](https://user-images.githubusercontent.com/5395277/70295369-c8e19300-17b4-11ea-8f3f-d4310647a8cc.png)


